### PR TITLE
Buck builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,10 @@
 *.exe
 *.out
 *.app
+
+# Buck
+/buck-out/
+/.buckd/
+/buckaroo/
+.buckconfig.local
+BUCKAROO_DEPS

--- a/BUCK
+++ b/BUCK
@@ -1,0 +1,11 @@
+prebuilt_cxx_library(
+  name = 'optional-lite',
+  header_namespace = '',
+  header_only = True,
+  exported_headers = subdir_glob([
+    ('include/nonstd', '**/*.hpp'),
+  ]),
+  visibility = [
+    'PUBLIC',
+  ],
+)

--- a/examples/01-to_int.cpp
+++ b/examples/01-to_int.cpp
@@ -16,7 +16,7 @@ optional<int> to_int( char const * const text )
 
 int main( int argc, char * argv[] )
 {
-    char * text = argc > 1 ? argv[1] : "42";
+    const char * text = argc > 1 ? argv[1] : "42";
 
     optional<int> oi = to_int( text );
 

--- a/examples/BUCK
+++ b/examples/BUCK
@@ -1,0 +1,38 @@
+cxx_binary(
+  name = '01-to_int',
+  srcs = [
+    '01-to_int.cpp',
+  ],
+  compiler_flags = [
+    '-std=c++11',
+  ],
+  deps = [
+    '//:optional-lite',
+  ],
+)
+
+cxx_binary(
+  name = '02-nodefltctor',
+  srcs = [
+    '02-nodefltctor.cpp',
+  ],
+  compiler_flags = [
+    '-std=c++11',
+  ],
+  deps = [
+    '//:optional-lite',
+  ],
+)
+
+cxx_binary(
+  name = '04-any-optional-variant',
+  srcs = [
+    '04-any-optional-variant.cpp',
+  ],
+  compiler_flags = [
+    '-std=c++11',
+  ],
+  deps = [
+    '//:optional-lite',
+  ],
+)

--- a/test/BUCK
+++ b/test/BUCK
@@ -1,0 +1,16 @@
+cxx_binary(
+  name = 'test',
+  header_namespace = '',
+  headers = glob([
+    '*.h',
+  ]),
+  srcs = glob([
+    '*.cpp',
+  ]),
+  compiler_flags = [
+    '-std=c++11',
+  ],
+  deps = [
+    '//:optional-lite',
+  ],
+)


### PR DESCRIPTION
This PR adds support for builds using [Buck](https://buckbuild.com/).

To run the examples:

```
buck run examples:01-to_int 
buck run examples:02-nodefltctor
buck run examples:04-any-optional-variant
```

I also had to add `const` to one of the examples so that it compiles on macOS/Clang. 

To run the tests:

```
buck run test
```

The existing CMake build is unchanged; the two can coexist peacefully 😊