### PR TITLE
Fix VS 2013 build, fix clang struct/class mismatch warnings

### DIFF
--- a/include/nonstd/optional.hpp
+++ b/include/nonstd/optional.hpp
@@ -735,8 +735,7 @@ public:
 
     optional_constexpr value_type const && operator *() const optional_refref_qual
     {
-        assert( has_value() );
-        return std::move( contained.value() );
+      return assert( has_value() ), std::move( contained.value() );
     }
 
     optional_constexpr14 value_type && operator *() optional_refref_qual
@@ -1071,7 +1070,7 @@ using namespace optional_lite;
 namespace std {
 
 template< class T >
-class hash< nonstd::optional<T> >
+struct hash< nonstd::optional<T> >
 {
 public:
     std::size_t operator()( nonstd::optional<T> const & v ) const optional_noexcept


### PR DESCRIPTION
Fixes `-Wall -Wpedantic -Werror` Clang builds stopping at struct/class hash mismatch.

Fixes VS 2013 builds, as it doesn't support multiline constexpr functions.