### PR TITLE
Getting rid of `conversion from ‘long unsigned int’ to ‘unsigned int' may change value`-messages

### DIFF
--- a/include/nonstd/optional.hpp
+++ b/include/nonstd/optional.hpp
@@ -445,7 +445,7 @@ template< typename T >
 struct alignment_of
 {
     enum { value = alignment_logic<
-        sizeof( alignment_of_hack<T> ) - sizeof(T), sizeof(T) >::value, };
+        static_cast<unsigned>(sizeof( alignment_of_hack<T> ) - sizeof(T)), static_cast<unsigned>(sizeof(T)) >::value, };
 };
 
 template< typename List, size_t N >


### PR DESCRIPTION
When compiling with -Wconversion in gcc 8, I'm getting the following warning:

    error: conversion from ‘long unsigned int’ to ‘unsigned int’ may change value [-Werror=conversion]

This warning can be removed relatively simply by the following commit.