### PR TITLE
Getting rid of `conversion from ‘long unsigned int’ to ‘unsigned int' may change value`-messages

### DIFF
--- a/include/nonstd/optional.hpp
+++ b/include/nonstd/optional.hpp
@@ -435,7 +435,7 @@ struct alignment_of_hack
     alignment_of_hack();
 };
 
-template <std::size_t A, std::size_t S>
+template <size_t A, size_t S>
 struct alignment_logic
 {
     enum { value = A < S ? A : S };

--- a/include/nonstd/optional.hpp
+++ b/include/nonstd/optional.hpp
@@ -435,7 +435,7 @@ struct alignment_of_hack
     alignment_of_hack();
 };
 
-template <unsigned A, unsigned S>
+template <std::size_t A, std::size_t S>
 struct alignment_logic
 {
     enum { value = A < S ? A : S };


### PR DESCRIPTION
When compiling with -Wconversion in gcc 8, I'm getting the following warning:

    error: conversion from ‘long unsigned int’ to ‘unsigned int’ may change value [-Werror=conversion]

This warning can be removed relatively simply by the following commit.

Noote, this is a follow up from #24, with a better solution.