### PR TITLE
Add an optional install step into the cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,4 +42,6 @@ if ( OPTIONAL_LITE_OPT_BUILD_EXAMPLES )
     add_subdirectory( example )
 endif()
 
+install(DIRECTORY include/nonstd DESTINATION include)
+
 # end of file


### PR DESCRIPTION
This is required, in particular, if the library is used in build-systems like yocto.