### PR TITLE
Support conan.io (including CMake-Config)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,11 +19,11 @@ option( OPTIONAL_LITE_OPT_BUILD_EXAMPLES "Build optional-lite examples" OFF )
 option( OPTIONAL_LITE_OPT_SELECT_STD     "Select std::optional"    OFF )
 option( OPTIONAL_LITE_OPT_SELECT_NONSTD  "Select nonstd::optional" OFF )
 
-project( optional_lite LANGUAGES CXX )
+project( optional_lite LANGUAGES CXX VERSION ${optional_lite_version})
 
 include( GNUInstallDirs )
 
-set( package_name "optional-lite" )
+set( package_name "optional_lite" )
 set( include_source_dir "${PROJECT_SOURCE_DIR}/include" )
 
 # Interface library:
@@ -32,7 +32,7 @@ add_library(
     ${package_name} INTERFACE )
 
 target_include_directories(
-    ${package_name} INTERFACE "$<BUILD_INTERFACE:${include_source_dir}>" )
+    ${package_name} INTERFACE "$<BUILD_INTERFACE:${include_source_dir}>" "$<INSTALL_INTERFACE:include>")
 
 # Installation:
 
@@ -50,5 +50,42 @@ endif()
 if ( OPTIONAL_LITE_OPT_BUILD_EXAMPLES )
     add_subdirectory( example )
 endif()
+
+#
+# Create Config Files
+#
+install(TARGETS ${package_name}
+    EXPORT Targets
+    INCLUDES DESTINATION include
+    )
+
+install(EXPORT Targets
+    FILE ${PROJECT_NAME}Targets.cmake
+    DESTINATION share/cmake/${PROJECT_NAME}
+    )
+
+#
+# Export Library
+#
+include(CMakePackageConfigHelpers)
+
+write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMinorVersion
+    )
+
+configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/script/LibraryConfig.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+    @ONLY
+    )
+
+install(
+    FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+    DESTINATION
+        . # Root Directory
+    )
 
 # end of file

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,23 @@
+from conans import ConanFile, CMake
+
+class optional_liteConan(ConanFile):
+    name = "optional_lite"
+    version = "3.1.1"
+    license = "Boost Software License - Version 1.0"
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+    description = "Expected objects for C++11 and later"
+    author = "Karl Wallner <kwallner@mail.de>"
+    url = 'git@github.com:kwallner/optional-lite.git'
+    scm = { "type": "git", "url": "auto", "revision": "auto" }
+    no_copy_source = True
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+        cmake.install()
+        cmake.test()
+        
+    def package_info(self):
+        self.env_info.optional_lite_DIR = self.package_folder

--- a/script/LibraryConfig.cmake.in
+++ b/script/LibraryConfig.cmake.in
@@ -1,0 +1,3 @@
+include(CMakeFindDependencyMacro)
+
+include("${CMAKE_CURRENT_LIST_DIR}/share/cmake/@PROJECT_NAME@/@PROJECT_NAME@Targets.cmake")


### PR DESCRIPTION
Hi,

my task was to make Jinja2Cpp to use conan.io. As this package requires some of your xxx-lite packages I also started to port them to conan. I have made almost equal changes to expected-lite, value-ptr-lite and expected-lite. 

Changes:
* Conan support (conanfile.py added)
* CMake-Find support (added generation of Config file in CMakeLists.txt)
* Package name uses underscore (as dash is not valid in python-identifiers)

Short HowTo:  
* Install conan 
* Go to the source directory and call `conan create . <user>/<channel>` (user is up to you, channel might be testing)