### PR TITLE
Fixes for clang-tidy

### DIFF
--- a/include/nonstd/optional.hpp
+++ b/include/nonstd/optional.hpp
@@ -912,7 +912,9 @@ public:
     : has_value_( other.has_value() )
     {
         if ( other.has_value() )
+        {
             contained.construct_value( T{ other.contained.value() } );
+        }
     }
 #endif // optional_CPP11_OR_GREATER
 
@@ -938,7 +940,9 @@ public:
     : has_value_( other.has_value() )
     {
         if ( other.has_value() )
+        {
             contained.construct_value( other.contained.value() );
+        }
     }
 
 #if optional_CPP11_OR_GREATER
@@ -962,7 +966,9 @@ public:
     : has_value_( other.has_value() )
     {
         if ( other.has_value() )
+        {
             contained.construct_value( T{ std::move( other.contained.value() ) } );
+        }
     }
 
     // 5a (C++11) - non-explicit converting move-construct from optional
@@ -985,7 +991,9 @@ public:
     : has_value_( other.has_value() )
     {
         if ( other.has_value() )
+        {
             contained.construct_value( std::move( other.contained.value() ) );
+        }
     }
 
     // 6 (C++11) - in-place construct
@@ -1123,8 +1131,14 @@ public:
         )
     operator=( U && value )
     {
-        if ( has_value() ) contained.value() = std::forward<U>( value );
-        else               initialize( T( std::forward<U>( value ) ) );
+        if ( has_value() )
+        {
+            contained.value() = std::forward<U>( value );
+        }
+        else
+        {
+            initialize( T( std::forward<U>( value ) ) );
+        }
         return *this;
     }
 


### PR DESCRIPTION
Fixes check google-readability-braces-around-statements (#40)