### PR TITLE
Add settings options to conanfile.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,6 +9,7 @@ class OptionalLiteConan(ConanFile):
     exports_sources = "include/nonstd/*", "CMakeLists.txt", "cmake/*", "LICENSE.txt"
     build_policy = "missing"
     author = "Martin Moene"
+    settings = "compiler", "build_type", "arch"
 
     def build(self):
         """Avoid warning on build step"""


### PR DESCRIPTION
Settings will be removed from package_id after calling `self.info.header_only()`, but they a helpfull for Conan CMake helper to detect generator correctly.
