### PR TITLE
Enhance in_place construction

### DIFF
--- a/include/nonstd/optional.hpp
+++ b/include/nonstd/optional.hpp
@@ -1106,7 +1106,7 @@ public:
     >
     optional_constexpr explicit optional( nonstd_lite_in_place_t(T), Args&&... args )
     : has_value_( true )
-    , contained( T( std::forward<Args>(args)...) )
+    , contained( in_place, std::forward<Args>(args)... )
     {}
 
     // 7 (C++11) - in-place construct,  initializer-list

--- a/test/optional.t.cpp
+++ b/test/optional.t.cpp
@@ -223,6 +223,17 @@ CASE( "optional: Allows to default construct an empty optional with a non-defaul
     EXPECT( !ondcm );
 }
 
+
+CASE( "optional: construct an immovable object" )
+{
+#if optional_CPP11_OR_GREATER
+    optional<NoDefaultCopyMove> ondcm(in_place, std::string("test"));
+    EXPECT( ondcm.has_value() );
+#else
+    EXPECT( !!"optional: in-place construction is not available (no C++11)" );
+#endif
+}
+
 CASE( "optional: Allows to copy-construct from empty optional (2)" )
 {
     optional<int> a;
@@ -486,11 +497,7 @@ CASE( "optional: Allows to in-place copy-construct from value (C++11, 6)" )
 
     EXPECT( a->first        == 'a' );
     EXPECT( a->second.value ==  7  );
-#if optional_USES_STD_OPTIONAL
     EXPECT( a->second.state == copy_constructed );
-#else
-    EXPECT( a->second.state == move_constructed );
-#endif
     EXPECT(         s.state != moved_from       );
 #else
     EXPECT( !!"optional: in-place construction is not available (no C++11)" );


### PR DESCRIPTION
The current implementation required ad least a move-constructor for
in-place construction.
This made it impossible to directly, create an optional of a type
without copy and move operators.

A workaround is using the variadic emplace function, but it requires to
construct the object in two steps.

std::optional does not require any copy or move operation for in-place
construction