### PR TITLE
optional as a literal type 

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,7 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "optional-lite",
+    hdrs = ["include/nonstd/optional.hpp"],
+    visibility = ["//visibility:public"],
+)

--- a/test/optional.t.cpp
+++ b/test/optional.t.cpp
@@ -201,6 +201,22 @@ CASE( "optional: Allows to default construct an empty optional (1a)" )
     EXPECT( !a );
 }
 
+CASE( "optional: usable in constant expression context" )
+{
+#if optional_CPP14_OR_GREATER
+
+    static constexpr optional<int> a;
+    static_assert(not a, "");
+
+    static constexpr optional<int> b{1};
+    static_assert(b, "");
+    static_assert(1 == b.value(), "");
+
+#else
+    EXPECT( !!"optional: not constructible in constant expressions" );
+#endif
+}
+
 CASE( "optional: Allows to explicitly construct a disengaged, empty optional via nullopt (1b)" )
 {
     optional<int> a( nullopt );


### PR DESCRIPTION
Hi Martin,

I've created a draft PR to allow use optional types within constant expressions. Can you let me know if this is something you would be interested in accepting and if so, is this the right direction? I have never written code for C++03 and very little for C++11 and would appreciate any guidance from you.