### PR TITLE
Convert CHANGES.txt to UTF-8 (from, apparently, Windows-1252)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,4 @@
-Changes for Optional Lite – A single-file header-only [type-safe C++17-like any, a] type-safe container for single values of any type for C++98, C++11 and later
+Changes for Optional Lite â€“ A single-file header-only [type-safe C++17-like any, a] type-safe container for single values of any type for C++98, C++11 and later
 
 1.0.2 - 2015-04-14
 


### PR DESCRIPTION
The sole non-ASCII character becomes an en dash, which is almost certainly what was intended.